### PR TITLE
Addition of scenarios for copying/cutting/pasting text and redo, as well as toggling on and off.

### DIFF
--- a/tests/400-serlo-editor.ts
+++ b/tests/400-serlo-editor.ts
@@ -90,7 +90,7 @@ Scenario('Markdown list shortcut', async ({ I }) => {
   I.seeElement('ul[data-slate-node="element"]')
 })
 
-Scenario('Copy/Paste text', async ({ I }) => {
+Scenario('Copy/paste text', async ({ I }) => {
   I.amOnPage('/entity/repository/add-revision/74888')
 
   I.click('span[data-slate-node="text"]')
@@ -101,11 +101,37 @@ Scenario('Copy/Paste text', async ({ I }) => {
 
   I.see('TESTTESTTEST')
 
-  I.doubleClick('span[data-slate-node="text"]')
+  for (let i = 0; i < 12; i++) {
+    I.pressKey(['Shift', 'LeftArrow'])
+  }
 
   I.pressKey(['Ctrl', 'C'])
 
   I.pressKey('Backspace')
+
+  I.dontSee('TESTTESTTEST')
+
+  I.pressKey(['Ctrl', 'V'])
+
+  I.see('TESTTESTTEST')
+})
+
+Scenario('Cut/paste text', async ({ I }) => {
+  I.amOnPage('/entity/repository/add-revision/74888')
+
+  I.click('span[data-slate-node="text"]')
+
+  I.type(' ')
+
+  I.type('TESTTESTTEST')
+
+  I.see('TESTTESTTEST')
+
+  for (let i = 0; i < 12; i++) {
+    I.pressKey(['Shift', 'LeftArrow'])
+  }
+
+  I.pressKey(['Ctrl', 'X'])
 
   I.dontSee('TESTTESTTEST')
 

--- a/tests/400-serlo-editor.ts
+++ b/tests/400-serlo-editor.ts
@@ -76,6 +76,26 @@ Scenario('Undo', async ({ I }) => {
   I.dontSee('Some text')
 })
 
+Scenario('Redo', async ({ I }) => {
+  I.amOnPage('/entity/create/Article/1377')
+
+  I.click('Füge ein Element hinzu')
+
+  I.pressKey('Backspace')
+
+  I.type('Some text')
+
+  I.see('Some text')
+
+  I.click('button[title="Undo"]')
+
+  I.dontSee('Some text')
+
+  I.click('button[title="Redo"]')
+
+  I.see('Some text')
+})
+
 Scenario('Markdown list shortcut', async ({ I }) => {
   I.amOnPage('/entity/create/Article/1377')
 
@@ -90,7 +110,7 @@ Scenario('Markdown list shortcut', async ({ I }) => {
   I.seeElement('ul[data-slate-node="element"]')
 })
 
-Scenario('Copy/paste text', async ({ I }) => {
+Scenario('Copy/cut/paste text', async ({ I }) => {
   I.amOnPage('/entity/repository/add-revision/74888')
 
   I.click('span[data-slate-node="text"]')
@@ -114,28 +134,24 @@ Scenario('Copy/paste text', async ({ I }) => {
   I.pressKey(['Ctrl', 'V'])
 
   I.see('TESTTESTTEST')
-})
-
-Scenario('Cut/paste text', async ({ I }) => {
-  I.amOnPage('/entity/repository/add-revision/74888')
-
-  I.click('span[data-slate-node="text"]')
-
-  I.type(' ')
-
-  I.type('TESTTESTTEST')
-
-  I.see('TESTTESTTEST')
 
   for (let i = 0; i < 12; i++) {
+    I.pressKey('Backspace')
+  }
+
+  I.type('CUTCUTCUT')
+
+  I.see('CUTCUTCUT')
+
+  for (let i = 0; i < 9; i++) {
     I.pressKey(['Shift', 'LeftArrow'])
   }
 
   I.pressKey(['Ctrl', 'X'])
 
-  I.dontSee('TESTTESTTEST')
+  I.dontSee('CUTCUTCUT')
 
   I.pressKey(['Ctrl', 'V'])
 
-  I.see('TESTTESTTEST')
+  I.see('CUTCUTCUT')
 })

--- a/tests/400-serlo-editor.ts
+++ b/tests/400-serlo-editor.ts
@@ -89,3 +89,27 @@ Scenario('Markdown list shortcut', async ({ I }) => {
 
   I.seeElement('ul[data-slate-node="element"]')
 })
+
+Scenario('Copy/Paste text', async ({ I }) => {
+  I.amOnPage('/entity/repository/add-revision/74888')
+
+  I.click('span[data-slate-node="text"]')
+
+  I.type(' ')
+
+  I.type('TESTTESTTEST')
+
+  I.see('TESTTESTTEST')
+
+  I.doubleClick('span[data-slate-node="text"]')
+
+  I.pressKey(['Ctrl', 'C'])
+
+  I.pressKey('Backspace')
+
+  I.dontSee('TESTTESTTEST')
+
+  I.pressKey(['Ctrl', 'V'])
+
+  I.see('TESTTESTTEST')
+})

--- a/tests/400-serlo-editor.ts
+++ b/tests/400-serlo-editor.ts
@@ -155,3 +155,72 @@ Scenario('Copy/cut/paste text', async ({ I }) => {
 
   I.see('CUTCUTCUT')
 })
+
+Scenario('Toggle on and off', async ({ I }) => {
+  I.amOnPage('/entity/create/Article/1377')
+
+  I.click('Füge ein Element hinzu')
+
+  I.pressKey('Backspace')
+
+  I.type('Some text')
+
+  I.see('Some text')
+
+  I.pressKey(['Ctrl', 'A'])
+
+  //Bold + Italic
+
+  I.pressKey(['Ctrl', 'I'])
+
+  I.pressKey(['Ctrl', 'B'])
+
+  //can't proof → id or name of bold/italic button is missing
+
+  //Create Link
+
+  //Use Hack because a id or name of link button is missing
+
+  I.pressKey(['Ctrl', 'K'])
+
+  I.type('https://serlo.org')
+
+  I.click('span[data-slate-string="true"]')
+
+  I.seeElement(
+    'a[href="https://de.serlo.org/" data-slate-node="element" data-slate-inline="true" style="cursor: pointer;"]'
+  )
+
+  I.seeElement('span[data-slate-leaf="true"]')
+
+  I.click('Some text')
+
+  I.amOnPage('https://serlo.org')
+
+  I.pressKey(['Alt', 'LeftArrow'])
+
+  I.amOnPage('/entity/create/Article/1377')
+
+  //delete Link
+  I.click('Füge ein Element hinzu')
+
+  I.pressKey('Backspace')
+
+  I.type('Some text')
+
+  I.see('Some text')
+
+  I.pressKey(['Ctrl', 'A'])
+
+  I.pressKey(['Ctrl', 'K'])
+
+  I.type('https://serlo.org')
+
+  I.click('span[data-slate-string="true"]')
+
+  I.pressKey(['Ctrl', 'A'])
+
+  I.pressKey(['Ctrl', 'K'])
+
+  //Can't proof → id of link button is missing
+})


### PR DESCRIPTION
I have written a test for the scenario of copying, cutting, and pasting text. It calls the test page, writes a sample text, copies it, deletes it, and then pastes it back. Then it writes another sample text, cuts it, and pastes it back.
After that, I wrote a test for the redo scenario. It calls the test page, adds an element, writes a sample text, clicks on Undo, and then on Redo.
Afterwards, I attempted to write the tests for the toggle on and off scenario. However, I encountered the problem that without IDs for the text menu, I am unable to verify the changes, such as text in italics or a hyperlink.