### PR TITLE
fix(400-serlo-editor): make unordered list shortcuts assertions more specific

### DIFF
--- a/tests/400-serlo-editor.ts
+++ b/tests/400-serlo-editor.ts
@@ -520,13 +520,17 @@ Scenario('Unordered list shortcuts', async ({ I }) => {
 
   I.pressKey('Backspace')
 
-  I.seeElement({ css: '.serlo-editor-hacks ul:not(.unstyled-list)' })
+  I.seeElement({
+    css: '.serlo-editor-hacks div[data-slate-editor="true"] ul:not(.unstyled-list)',
+  })
 
   //Remove empty list item on backspace
 
   I.pressKey('Backspace')
 
-  I.dontSeeElement({ css: '.serlo-editor-hacks ul:not(.unstyled-list)' })
+  I.dontSeeElement({
+    css: '.serlo-editor-hacks div[data-slate-editor="true"] ul:not(.unstyled-list)',
+  })
 })
 
 Scenario('Toolbar Toggle on and off', async ({ I }) => {


### PR DESCRIPTION
New plugin toolbar will contain `ul` elements. Therefore, we can't rely on `.serlo-editor-hacks ul:not(.unstyled-list)` selector any more, we need to make it more specific. This PR adds a Slate-specific selector between the article wrapper and the unordered list.

Please feel free to suggest improvements or any adjustments that you'd prefer.